### PR TITLE
Fetch homepage authenticated for ClientTransaction init

### DIFF
--- a/twitter_cli/client.py
+++ b/twitter_cli/client.py
@@ -1103,6 +1103,15 @@ class TwitterClient:
             # a different TLS fingerprint on the same IP — a detection vector.
             cffi_session = _get_cffi_session()
             ct_headers = _gen_ct_headers()
+            # Fetch the homepage authenticated: the logged-out page no
+            # longer embeds the ondemand chunk map / loading-x-anim frames
+            # that transaction-ID generation parses, so an anonymous fetch
+            # always fails init and search requests go out without the
+            # x-client-transaction-id header (HTTP 404).
+            ct_headers["Cookie"] = self._cookie_string or (
+                "auth_token=%s; ct0=%s" % (self._auth_token, self._ct0)
+            )
+            ct_headers["X-Csrf-Token"] = self._ct0
             home_page = cffi_session.get(
                 "https://x.com", headers=ct_headers, timeout=10,
             )


### PR DESCRIPTION
## Problem

`twitter search` (and any endpoint requiring `x-client-transaction-id`) fails with HTTP 404, even with a fresh live `SearchTimeline` queryId from the community openapi file.

## Root cause

`_ensure_client_transaction` fetches `https://x.com` **anonymously**. The logged-out homepage no longer embeds either artifact `xclienttransaction` parses:

- the `ondemand.*` webpack chunk map (`ON_DEMAND_FILE_REGEX` finds nothing, so `.group(1)` raises `NoneType has no attribute group`, swallowed as a warning), and
- the `loading-x-anim` SVG frames.

So `ClientTransaction` never initializes, no `x-client-transaction-id` header is ever sent, and the search endpoint 404s every request. Feed/user endpoints do not require the header, which is why only search broke.

## Fix

Send the account `Cookie` + `X-Csrf-Token` with the init fetch. The **logged-in** homepage contains the chunk map, the animation frames, and the `twitter-site-verification` meta, so init succeeds.

Verified end-to-end on Windows (Brave 152, Python 3.13): the `Failed to init ClientTransaction` warning is gone and `twitter search "AI agent" -t Latest` returns `ok: true`.